### PR TITLE
Release bot config mount

### DIFF
--- a/openshift/deployment.yml.j2
+++ b/openshift/deployment.yml.j2
@@ -39,9 +39,12 @@ spec:
       - name: release-bot-secrets
         secret:
           secretName: release-bot-secrets
+      - name: release-bot-config
+        secret:
+          secretName: release-bot-config
       containers:
         - name: release-bot
-          image: docker.io/marusinm/release-bot:latest
+          image: docker.io/rpitonak/release-bot:latest
           ports:
           - containerPort: 8443
             protocol: TCP
@@ -53,8 +56,10 @@ spec:
           volumeMounts:
           - name: release-bot-secrets
             mountPath: /secrets
+          - name: release-bot-config
+            mountPath: /home/release-bot/.config
           command:
-            - "release-bot -c /secrets/prod/conf.yaml"
+            - "run.sh"
           resources:
             requests:
               memory: "128Mi"

--- a/openshift/secret-release-bot-secrets.yml.j2
+++ b/openshift/secret-release-bot-secrets.yml.j2
@@ -21,11 +21,11 @@
 # SOFTWARE.
 
 ---
-apiVersion: v1
-kind: Secret
-metadata:
+  apiVersion: v1
+  kind: Secret
+  metadata:
     name: release-bot-secrets
-type: Opaque
-data:
+  type: Opaque
+  data:
     # Github app cert
     private-key.pem: "{{ lookup('file', '../secrets/{{ deployment }}/private-key.pem') | b64encode }}"


### PR DESCRIPTION
We need to change image name once the new image supporting celery is deployed in docker hub.